### PR TITLE
utils: check type of

### DIFF
--- a/HinetPy/utils.py
+++ b/HinetPy/utils.py
@@ -102,6 +102,9 @@ def string2datetime(value):
     datetime.datetime(2010, 1, 1, 3, 45)
     """
 
+    if isinstance(value, datetime):
+        return value
+
     value = value.replace("T", " ")
     value = value.replace("-", " ")
     value = value.replace(":", " ")


### PR DESCRIPTION
The documentation says that start/end time can usually be of type string or datetime. The type check was missing. 