### PR TITLE
Use the new way to add bin to PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           if [ "$RUNNER_OS" == "macOS" ]; then sed -i.bak 's/malloc.h/stdlib.h/' win32tools/win2sac.src/s4read_data.c; fi
           cd win32tools; make; mkdir bin; mv catwin32.src/catwin32 win2sac.src/win2sac_32 bin/; cd ..
           # Add to PATH
-          echo "::add-path::${{ github.workspace }}/win32tools/bin"
+          echo "${{ github.workspace }}/win32tools/bin" >> $GITHUB_PATH
 
       - name: Run tests
         run: |


### PR DESCRIPTION
**Description of proposed changes**

See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
