### PR TITLE
Check invalid stations parameter type for Client.select_stations()

### DIFF
--- a/HinetPy/client.py
+++ b/HinetPy/client.py
@@ -1153,7 +1153,9 @@ class Client:
         """
         stations_selected = []
 
-        if isinstance(stations, str):  # stations is a str, i.e., one station
+        if stations is None:
+            pass
+        elif isinstance(stations, str):  # stations is a str, i.e., one station
             stations_selected.append(stations)
         elif isinstance(stations, list):
             stations_selected.extend(stations)

--- a/HinetPy/client.py
+++ b/HinetPy/client.py
@@ -1151,9 +1151,14 @@ class Client:
         0
 
         """
-        if stations is None:
-            stations = []
-        stations_selected = stations
+        stations_selected = []
+
+        if isinstance(stations, str):  # stations is a str, i.e., one station
+            stations_selected.append(stations)
+        elif isinstance(stations, list):
+            stations_selected.extend(stations)
+        else:
+            raise ValueError("stations should be either a str or a list.")
 
         # get station list from Hi-net server
         stations_at_server = self.get_station_list(code)


### PR DESCRIPTION
**Description of proposed changes**

In `Client.select_stations()`, the `stations` parameter can be either

- a string (for a single station)
- a list of string (for multiple stations)

The old code doesn't works for the str type. This PR fixes the issue.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
