### PR TITLE
BUG: Use shutil.move for cross-device file renaming

### DIFF
--- a/HinetPy/client.py
+++ b/HinetPy/client.py
@@ -525,7 +525,6 @@ class ContinuousWaveformClient(BaseClient):
             ctable = os.path.join(dirname, ctable)
         if dirname and not os.path.exists(dirname):
             os.makedirs(dirname, exist_ok=True)
-        #os.rename(ch_euc, ctable)
         shutil.move(ch_euc, ctable)
         # 4. cleanup
         if cleanup:

--- a/HinetPy/client.py
+++ b/HinetPy/client.py
@@ -13,6 +13,7 @@ import zipfile
 from datetime import datetime, timedelta
 from html.parser import HTMLParser
 from multiprocessing.pool import ThreadPool
+import shutil
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -524,8 +525,8 @@ class ContinuousWaveformClient(BaseClient):
             ctable = os.path.join(dirname, ctable)
         if dirname and not os.path.exists(dirname):
             os.makedirs(dirname, exist_ok=True)
-        os.rename(ch_euc, ctable)
-
+        #os.rename(ch_euc, ctable)
+        shutil.move(ch_euc, ctable)
         # 4. cleanup
         if cleanup:
             for cnt in cnts:


### PR DESCRIPTION
Fix a small bug:OSError: [Errno 18] Invalid cross-device link.

os.rename only works if source and destination are on the same file system. Use shutil.move instead.

**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
